### PR TITLE
improve(audio): use dasp for increased buffer sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4270,6 +4270,7 @@ name = "vm"
 version = "0.1.0"
 dependencies = [
  "dasp",
+ "itertools",
  "numquant",
  "proptest",
  "proptest-derive",
@@ -4281,7 +4282,9 @@ name = "vm_glitch"
 version = "0.1.0"
 dependencies = [
  "atomic_float 1.1.0",
+ "dasp",
  "drawille",
+ "itertools",
  "lang",
  "nih_plug",
  "nih_plug_vizia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,11 @@ triple_buffer = "8.0.0"
 # the GPL compatibility requirement
 # nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git", default-features = false, features = ["assert_process_allocs"] }
 vm = {path = "./vm"}
+dasp = { workspace = true }
+itertools = "0.13.0"
+
+[workspace.dependencies]
+dasp = { version = "0.11.0", features = [ "all" ] }
 
 [profile.release]
 lto = "thin"

--- a/src/delay_buffer.rs
+++ b/src/delay_buffer.rs
@@ -1,46 +1,31 @@
+use dasp::ring_buffer::Fixed;
+use dasp::*;
+use nih_plug::buffer::Buffer;
+
 pub struct DelayBuffer {
-    pub buffer: Vec<Vec<f32>>,
+    pub buffer: Fixed<Vec<[f32; 2]>>,
 }
 
 impl DelayBuffer {
     pub fn new(len: usize) -> Self {
         Self {
-            buffer: vec![vec![0.0; len], vec![0.0; len]],
-        }
-    }
-    // TODO maybe make private and call in [ingest_audio]
-    /// Copy second half to first half in preparation for new samples
-    pub fn copy_to_back(&mut self) {
-        for chan in self.buffer.iter_mut() {
-            let len = chan.len();
-            chan.copy_within(len / 2..len, 0);
-        }
-    }
-    /// Copy audio buffer to second half of self
-    pub fn ingest_audio(&mut self, audio: &mut [&mut [f32]]) {
-        for (self_chan, audio_chan) in self.buffer.iter_mut().zip(audio.iter()) {
-            let self_len = self_chan.len();
-            for (self_sample, audio_sample) in self_chan
-                .iter_mut()
-                .skip(self_len / 2)
-                .zip(audio_chan.iter())
-            {
-                *self_sample = *audio_sample;
-            }
+            buffer: Fixed::from(vec![[0.0, 0.0]; len]),
         }
     }
 
-    /// Copy first half (oldest) to audio buffer
-    pub fn write_to_audio(&self, audio: &mut [&mut [f32]]) {
-        for (self_chan, audio_chan) in self.buffer.iter().zip(audio.iter_mut()) {
-            for (self_sample, audio_sample) in self_chan.iter().zip(audio_chan.iter_mut()) {
-                *audio_sample = *self_sample;
-            }
+    /// Push incoming samples to the back of the buffer
+    pub fn ingest_audio(&mut self, audio: &mut Buffer) {
+        let audio = audio.as_slice();
+        for (left, right) in audio[0].iter().zip(audio[1].iter()) {
+            self.buffer.push([*left, *right]);
         }
     }
 
-    /// Can't return `&mut [&mut [f32]]` like nih_plug does cause it requires unsafe nastiness
-    pub fn as_mut_slice(&mut self) -> &mut [Vec<f32>] {
-        &mut self.buffer
+    /// Copy front to the audio buffer
+    pub fn write_to_audio(&self, audio: &mut Buffer) {
+        for (frame, mut chan_iter) in self.buffer.iter().zip(audio.iter_samples()) {
+            *chan_iter.get_mut(0).unwrap() = frame[0];
+            *chan_iter.get_mut(1).unwrap() = frame[1];
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ impl Default for VmGlitch {
             to_ui_buffer: (to_ui.0, Some(to_ui.1)),
             from_ui_buffer: (Some(from_ui.0), from_ui.1),
             // ??? use audio buffer * 2, which is dynamic ofc
-            delay_buffer: DelayBuffer::new(1024),
+            delay_buffer: DelayBuffer::new(8192),
         }
     }
 }
@@ -173,16 +173,14 @@ impl Plugin for VmGlitch {
                 .copy_from_slice(updated_bytecode.as_slice());
         }
 
-        self.delay_buffer.copy_to_back();
-        self.delay_buffer.ingest_audio(buffer.as_slice());
+        self.delay_buffer.ingest_audio(buffer);
 
         self.vm.run(
             self.to_ui_buffer.0.input_buffer(), // stage updates for the UI thread without publishing yet
-            self.delay_buffer.as_mut_slice(),
-            samples,
+            &mut self.delay_buffer.buffer,
         );
 
-        self.delay_buffer.write_to_audio(buffer.as_slice());
+        self.delay_buffer.write_to_audio(buffer);
 
         self.to_ui_buffer.0.publish();
 

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+dasp = { workspace = true }
+itertools = "0.13.0"
 numquant = "0.2.0"
+rustfft = "6.2.0"
 
 [dev-dependencies]
 proptest = "1.6.0"


### PR DESCRIPTION
added dasp and replaced the underlying buffer for DelayBuffer with dasp::ring_buffer

+ ➕  now able to easily increase buffer to arbitrary sizes
+ ➕  dasp seems super useful so will probably be used more extensively
+ ➕  removed a bunch of logic for maintaining our own budget ring buffer
- ➖  we lose the ability to `copy_within` because the ring_buffer has two slices internally. Seems unavoidable.
- ➖  haven't used dasp's traits to simplify any logic as I need more time to get to know it