### PR TITLE
Update cargo to use remote dependency url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2539,6 +2539,7 @@ dependencies = [
 [[package]]
 name = "nih_plug"
 version = "0.0.0"
+source = "git+https://github.com/rosofo/nih-plug.git?rev=e04efa0#e04efa0004876f438079e9072af89b08cf36a46b"
 dependencies = [
  "anyhow",
  "anymap",
@@ -2580,6 +2581,7 @@ source = "git+https://github.com/robbert-vdh/nih_plug_assets.git#a04e327923e120b
 [[package]]
 name = "nih_plug_derive"
 version = "0.1.0"
+source = "git+https://github.com/rosofo/nih-plug.git?rev=e04efa0#e04efa0004876f438079e9072af89b08cf36a46b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2589,6 +2591,7 @@ dependencies = [
 [[package]]
 name = "nih_plug_vizia"
 version = "0.0.0"
+source = "git+https://github.com/rosofo/nih-plug.git?rev=e04efa0#e04efa0004876f438079e9072af89b08cf36a46b"
 dependencies = [
  "baseview 0.1.0 (git+https://github.com/RustAudio/baseview.git?rev=2c1b1a7b0fef1a29a5150a6a8f6fef6a0cbab8c4)",
  "crossbeam",
@@ -2601,6 +2604,7 @@ dependencies = [
 [[package]]
 name = "nih_plug_xtask"
 version = "0.1.0"
+source = "git+https://github.com/rosofo/nih-plug.git?rev=e04efa0#e04efa0004876f438079e9072af89b08cf36a46b"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ drawille = "0.3.0"
 lang = { version = "0.1.0", path = "lang" }
 # Remove the `assert_process_allocs` feature to allow allocations on the audio
 # thread in debug builds.
-nih_plug = { path = "../nih-plug", features = ["assert_process_allocs", "standalone", "vst3"], default-features = false }
-nih_plug_vizia = { path = "../nih-plug/nih_plug_vizia" }
+nih_plug = { git = "https://github.com/rosofo/nih-plug.git", rev = "e04efa0", features = ["assert_process_allocs", "standalone", "vst3"], default-features = false }
+nih_plug_vizia = {  git = "https://github.com/rosofo/nih-plug.git", rev = "e04efa0" }
 triple_buffer = "8.0.0"
 # Uncomment the below line to disable the on-by-default VST3 feature to remove
 # the GPL compatibility requirement

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nih_plug_xtask = { path = "../../nih-plug/nih_plug_xtask" }
+nih_plug_xtask = { git = "https://github.com/rosofo/nih-plug.git", rev = "e04efa0" }


### PR DESCRIPTION
This makes building on other machines and pipelines easier, but can be a little harder to work with locally

I used git hash instead of branch, for reproducability, but have no strong feelings about it