### PR TITLE
Repeat Groups

### DIFF
--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 [dependencies]
 ariadne = "0.5.0"
 chumsky = "1.0.0-alpha.7"
+color-eyre = "0.6.3"
+eyre = "0.6.12"
 itertools = "0.13.0"
 thiserror = "2.0.9"
 variantly = "0.4.0"

--- a/lang/proptest-regressions/parse.txt
+++ b/lang/proptest-regressions/parse.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 58a73b211e9f3e4841e1333061eb75a540d79cd019f7dd0b30da601a578d5268 # shrinks to ops = ""

--- a/lang/src/assemble.rs
+++ b/lang/src/assemble.rs
@@ -80,7 +80,7 @@ pub fn assemble<'a>(
 
     Ok(bytecode)
 }
-/// Arbitrary error type for demonstration purposes
+
 #[derive(Debug, Error)]
 #[error("{0}")]
 struct AssembleError(&'static str);

--- a/lang/src/assemble.rs
+++ b/lang/src/assemble.rs
@@ -1,73 +1,75 @@
 use std::{fmt::Debug, ops::Range};
 
+use color_eyre::Section;
 use itertools::Itertools;
+use thiserror::Error;
 use vm::op::Opcode;
 
 use crate::parse::{Atom, Gtch};
-
-use thiserror::Error;
-#[derive(Debug, Error)]
-pub enum AssembleError {
-    #[error("Wrong type for argument {1} to `{0:?}`: {2:?}")]
-    Arg(Opcode, usize, Box<dyn Debug>),
-    #[error("Index for op {0:?} is greater than 255: {1}")]
-    Index(Opcode, usize),
-    #[error("Range for op {0:?} is empty: {1:?}")]
-    EmptyRange(Opcode, Range<usize>),
-}
 
 // i know i know it's really horrible, I tried to be clever about Results and let's hope I come to my senses sometime
 pub fn assemble<'a>(
     gtch: impl IntoIterator<Item = &'a Gtch>,
     bytecode_size: usize,
-) -> Result<Vec<u8>, Vec<AssembleError>> {
-    let bytecode = gtch.into_iter().map(|gtch| match gtch {
-        Gtch::Copy(i, j) => {
-            let j =
-                j.clone()
-                    .idx()
-                    .ok_or(AssembleError::Arg(Opcode::Copy, 1, Box::new(j.clone())))?;
-            Ok(match i {
-                Atom::Idx(i) => vec![Opcode::Copy as u8, *i as u8, j as u8],
-                Atom::Range(r) => {
-                    if r.is_empty() {
-                        return Err(AssembleError::EmptyRange(Opcode::Copy, r.clone()));
-                    }
-                    if r.len() + j > 255 {
-                        return Err(AssembleError::Index(Opcode::Copy, r.len() + j));
-                    }
+) -> Result<Vec<u8>, eyre::Report> {
+    let bytecode = gtch
+        .into_iter()
+        .map::<std::result::Result<Vec<u8>, AssembleError>, _>(|gtch| match gtch {
+            Gtch::Copy(i, j) => {
+                let j = j.clone().idx().ok_or(AssembleError(
+                    "Range cannot be used as second argument to Copy",
+                ))?;
+                Ok(match i {
+                    Atom::Idx(i) => vec![Opcode::Copy as u8, *i as u8, j as u8],
+                    Atom::Range(r) => {
+                        if r.is_empty() {
+                            return Err(AssembleError("Range must be nonempty"));
+                        }
+                        if r.len() + j > 255 {
+                            return Err(AssembleError("Range ends beyond the max index (255)"));
+                        }
 
-                    r.clone()
-                        .enumerate()
-                        .flat_map(|(i, k)| vec![Opcode::Copy as u8, k as u8, j as u8 + i as u8])
-                        .collect_vec()
-                }
-            })
-        }
-        Gtch::Jump(i) => {
-            let i =
-                i.clone()
+                        r.clone()
+                            .enumerate()
+                            .flat_map(|(i, k)| vec![Opcode::Copy as u8, k as u8, j as u8 + i as u8])
+                            .collect_vec()
+                    }
+                })
+            }
+            Gtch::Jump(i) => {
+                let i = i
+                    .clone()
                     .idx()
-                    .ok_or(AssembleError::Arg(Opcode::Jump, 0, Box::new(i.clone())))?;
-            Ok(vec![Opcode::Jump as u8, i as u8])
-        }
-        Gtch::Sample(i) => {
-            let i = i.clone().idx().ok_or(AssembleError::Arg(
-                Opcode::Sample,
-                0,
-                Box::new(i.clone()),
-            ))?;
-            Ok(vec![Opcode::Sample as u8, i as u8])
-        }
-        Gtch::Swap(i, j) => {
-            let i = i.clone().idx().ok_or_else(|| AssembleError::Arg(Opcode::Swap, 0, Box::new(i.clone())))?;
-            let j = j.clone().idx().ok_or_else(|| AssembleError::Arg(Opcode::Swap, 0, Box::new(j.clone())))?;
-            Ok(vec![Opcode::Swap as u8, i as u8, j as u8])
-        },
-    });
+                    .ok_or(AssembleError("Range cannot be used as argument to Jump"))?;
+                Ok(vec![Opcode::Jump as u8, i as u8])
+            }
+            Gtch::Sample(i) => {
+                let i = i
+                    .clone()
+                    .idx()
+                    .ok_or(AssembleError("Cannot sample a range"))?;
+                Ok(vec![Opcode::Sample as u8, i as u8])
+            }
+            Gtch::Swap(i, j) => {
+                let i = i
+                    .clone()
+                    .idx()
+                    .ok_or(AssembleError("Range cannot be used as argument to Swap"))?;
+                let j = j
+                    .clone()
+                    .idx()
+                    .ok_or(AssembleError("Range cannot be used as argument to Swap"))?;
+                Ok(vec![Opcode::Swap as u8, i as u8, j as u8])
+            }
+            _ => unreachable!(),
+        });
     let (bytecode, errs): (Vec<Vec<u8>>, Vec<AssembleError>) = bytecode.partition_result();
     if !errs.is_empty() {
-        return Err(errs);
+        return Err(errs
+            .into_iter()
+            .fold(eyre::eyre!("Assembly errors"), |report, err| {
+                report.error(err)
+            }));
     }
     let bytecode = bytecode
         .into_iter()
@@ -78,6 +80,10 @@ pub fn assemble<'a>(
 
     Ok(bytecode)
 }
+/// Arbitrary error type for demonstration purposes
+#[derive(Debug, Error)]
+#[error("{0}")]
+struct AssembleError(&'static str);
 
 #[cfg(test)]
 mod tests {

--- a/lang/src/compile.rs
+++ b/lang/src/compile.rs
@@ -1,3 +1,6 @@
+use std::iter::once;
+
+use itertools::Itertools;
 use vm::op::Op;
 
 use crate::{assemble::assemble, parse::Gtch};
@@ -17,6 +20,8 @@ pub fn compile(ast: &[Gtch]) -> Result<Vec<u8>, eyre::Report> {
         }
     }
 
+    println!("{:?}", ir);
+
     assemble(&ir, 512)
 }
 
@@ -27,22 +32,38 @@ fn unroll_repeat_group(repeats: usize, children: Vec<Gtch>) -> impl Iterator<Ite
     children
         .into_iter()
         .cycle()
-        .map(|mut node| {
+        .enumerate()
+        .map(move |(op_idx, mut node)| {
+            let group_idx = op_idx / len;
+
             node.copy_mut().map(|(i, j)| {
-                i.idx_mut().map(|i| *i += 1);
-                j.idx_mut().map(|j| *j += 1);
+                i.idx_mut().map(|i| *i += group_idx);
+                j.idx_mut().map(|j| *j += group_idx);
             });
             node.swap_mut().map(|(i, j)| {
-                i.idx_mut().map(|i| *i += 1);
-                j.idx_mut().map(|j| *j += 1);
+                i.idx_mut().map(|i| *i += group_idx);
+                j.idx_mut().map(|j| *j += group_idx);
             });
             node.jump_mut().map(|i| {
-                i.idx_mut().map(|i| *i += 1);
+                i.idx_mut().map(|i| *i += group_idx);
             });
             node.sample_mut().map(|i| {
-                i.idx_mut().map(|i| *i += 1);
+                i.idx_mut().map(|i| *i += group_idx);
             });
             node
         })
         .take(len * repeats)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parse;
+
+    use super::*;
+
+    #[test]
+    fn test_unrolling() {
+        let ast = parse::parse("[3 .0 1>2 ]").unwrap();
+        let bytecode = compile(&ast).unwrap();
+    }
 }

--- a/lang/src/compile.rs
+++ b/lang/src/compile.rs
@@ -1,0 +1,7 @@
+use vm::op::Op;
+
+use crate::parse::Gtch;
+
+pub fn compile(ast: &[Gtch]) -> Vec<Op> {
+    unimplemented!()
+}

--- a/lang/src/compile.rs
+++ b/lang/src/compile.rs
@@ -1,7 +1,48 @@
 use vm::op::Op;
 
-use crate::parse::Gtch;
+use crate::{assemble::assemble, parse::Gtch};
 
-pub fn compile(ast: &[Gtch]) -> Vec<Op> {
-    unimplemented!()
+pub fn compile(ast: &[Gtch]) -> Result<Vec<u8>, eyre::Report> {
+    let mut ir = vec![];
+
+    for node in ast.iter().cloned() {
+        if let Gtch::RepeatGroup {
+            max_iters,
+            children,
+        } = node
+        {
+            ir.extend(unroll_repeat_group(max_iters, children));
+        } else {
+            ir.push(node);
+        }
+    }
+
+    assemble(&ir, 512)
+}
+
+/// Unroll a repeated group statically, incrementing any arguments of the child ops
+#[allow(clippy::option_map_unit_fn)]
+fn unroll_repeat_group(repeats: usize, children: Vec<Gtch>) -> impl Iterator<Item = Gtch> {
+    let len = children.len();
+    children
+        .into_iter()
+        .cycle()
+        .map(|mut node| {
+            node.copy_mut().map(|(i, j)| {
+                i.idx_mut().map(|i| *i += 1);
+                j.idx_mut().map(|j| *j += 1);
+            });
+            node.swap_mut().map(|(i, j)| {
+                i.idx_mut().map(|i| *i += 1);
+                j.idx_mut().map(|j| *j += 1);
+            });
+            node.jump_mut().map(|i| {
+                i.idx_mut().map(|i| *i += 1);
+            });
+            node.sample_mut().map(|i| {
+                i.idx_mut().map(|i| *i += 1);
+            });
+            node
+        })
+        .take(len * repeats)
 }

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -2,3 +2,5 @@ pub mod assemble;
 pub mod parse;
 pub use ariadne::*;
 pub use chumsky::error::Rich;
+pub mod compile;
+pub mod mark;

--- a/lang/src/parse.rs
+++ b/lang/src/parse.rs
@@ -1,7 +1,7 @@
 use std::ops::Range;
 
 use ariadne::{Color, Label, Report, ReportKind, Source};
-use chumsky::prelude::*;
+use chumsky::{combinator, container::Seq, prelude::*};
 use variantly::Variantly;
 
 #[derive(Clone, Debug, Variantly)]
@@ -15,7 +15,11 @@ pub enum Gtch {
     Copy(Atom, Atom),
     Jump(Atom),
     Sample(Atom),
-    Swap(Atom, Atom)
+    Swap(Atom, Atom),
+    Loop {
+        iterations: Atom,
+        children: Vec<Gtch>,
+    },
 }
 
 fn parser<'a>() -> impl Parser<'a, &'a str, Vec<Gtch>, extra::Err<Rich<'a, char>>> {
@@ -42,7 +46,19 @@ fn parser<'a>() -> impl Parser<'a, &'a str, Vec<Gtch>, extra::Err<Rich<'a, char>
             .then(atom)
             .map(|(a1, a2)| Gtch::Swap(a1, a2));
 
-        choice((copy, jump, sample, swap)).padded().repeated().collect()
+        let parse_loop = just("[")
+            .ignore_then(atom)
+            .then(tree)
+            .then_ignore(just("]"))
+            .map(|(atom, children)| Gtch::Loop {
+                iterations: atom,
+                children,
+            });
+
+        choice((copy, jump, sample, swap, parse_loop))
+            .padded()
+            .repeated()
+            .collect()
     })
 }
 
@@ -65,7 +81,10 @@ pub fn parse(s: &str) -> Result<Vec<Gtch>, Vec<Rich<char>>> {
 
 #[cfg(test)]
 mod tests {
+    use crate::parse::{Atom, Gtch};
+
     use super::parse;
+    use proptest::prelude::*;
 
     #[test]
     fn test_parsing() {
@@ -76,5 +95,16 @@ mod tests {
     #[test]
     fn test_parsing_ranged() {
         parse("0-200>50").unwrap();
+    }
+
+    proptest! {
+        #[test]
+        fn test_parsing_loop(ops in prop::collection::vec(prop::sample::select(&[
+            "~0", "0>1", "0<>1", ".0"
+        ]), 0..10).prop_map(|ops| ops.join(" "))) {
+            let program = ["[0", &ops, "]"].join(" ");
+            let result = parse(&program);
+            result.unwrap();
+        }
     }
 }

--- a/lang/src/parse.rs
+++ b/lang/src/parse.rs
@@ -16,8 +16,8 @@ pub enum Gtch {
     Jump(Atom),
     Sample(Atom),
     Swap(Atom, Atom),
-    Loop {
-        iterations: usize,
+    RepeatGroup {
+        max_iters: usize,
         children: Vec<Gtch>,
     },
 }
@@ -51,8 +51,8 @@ fn parser<'a>() -> impl Parser<'a, &'a str, Vec<Gtch>, extra::Err<Rich<'a, char>
             .padded()
             .then(tree.or_not().padded())
             .delimited_by(just("["), just("]"))
-            .map(|(iterations, children)| Gtch::Loop {
-                iterations,
+            .map(|(iterations, children)| Gtch::RepeatGroup {
+                max_iters: iterations,
                 children: children.unwrap_or(vec![]),
             });
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -31,8 +31,8 @@ impl Model for Data {
                 match parsed {
                     Ok(gtch) => {
                         self.errs = "".to_string();
-                        let bytecode = lang::assemble::assemble(
-                            gtch.iter(),
+                        let bytecode = lang::compile::compile(
+                            &gtch,
                             self.from_vm_buffer
                                 .lock()
                                 .unwrap()
@@ -41,12 +41,7 @@ impl Model for Data {
                         );
                         let Ok(bytecode) = bytecode else {
                             let errs = bytecode.unwrap_err();
-                            for err in errs.iter() {
-                                let mut report = Report::build(ReportKind::Error, 0..str.len())
-                                    .with_message(err.to_string());
-                                report.add_note(err);
-                                report.finish().eprint(Source::from(&str)).unwrap();
-                            }
+                            println!("{}", errs);
                             self.errs = format!("{:#?}", errs);
                             return;
                         };


### PR DESCRIPTION
Essentially a macro that expands to repeat the contained ops N times, with a twist: the index of every op is incremented by 1 on each repeat

e.g. `[3 .0 ]` unrolls to `.0 .1. 2`, `[3 0<>1 .2]` to `0<> 1 .2 1<>2 .3 2<>3 .4`

things I gotta follow up

- nesting groups will probably crash the plugin atm because the compiler will skip unrolling the inner group and send it as is to the assembler, which will promptly crap out
- syntax is needlessly inventive. Maybe it should be changed to `N * [OPs]`/`N * (OPs)`