### PR TITLE
Update justfile to support linux

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,10 +1,21 @@
+vst3_dir := if os() == "macos" {
+    x"~/Library/Audio/Plug-Ins/VST3"
+} else if os() == "linux" {
+    x"~/.vst3"
+} else {
+    error("Unsupported OS: '{{os()}}'")
+}
+
+# The CoreAudio SDK is required for universal bundle building
+bundle_command := if os() == "macos" { "bundle-universal" } else { "bundle" }
+
 bundle *CARGO_ARGS: && install
     @echo "Pass '-F tracing' to bundle with tracing enabled"
-    cargo xtask bundle-universal vm_glitch --release {{CARGO_ARGS}}
+    cargo xtask {{bundle_command}} vm_glitch --release {{CARGO_ARGS}}
 
 install:
-    rm -rf ~/Library/Audio/Plug-Ins/VST3/VM\ Glitch.vst3
-    cp -r target/bundled/VM\ Glitch.vst3 ~/Library/Audio/Plug-Ins/VST3/
+    rm -rf "{{vst3_dir}}/VM Glitch.vst3"
+    cp -r "target/bundled/VM Glitch.vst3" "{{vst3_dir}}/VM Glitch.vst3"
 
 trace:
     @echo "Starting the profiler frontend."


### PR DESCRIPTION
Linux stores vst3 plugins in a different place, to macos, alongside this we cannot use bundle-universal easily on linux as it expects to have access to the core-audio sdk. Of course we should not ship plugins in the end to users only built for x86-64-linux but it improves build experience for linux users to do a seamless build and get hacking